### PR TITLE
[APP-914] Update Google Maps Clustering name. Also, only master shoul…

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,10 +1,15 @@
+env:
+  JAVA_HOME: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+
 steps:
-  - command: "./gradlew :library:clean :library:assembleRelease :library:assembleDebug :library:artifactoryPublish"
-    label: "Build"
+  - label: "Build"
+    command: "./gradlew :library:clean :library:assembleRelease :library:assembleDebug"
     agents:
       - "queue=link-tablet"
-    env:
-      JAVA_HOME: "/usr/lib/jvm/java-1.8.0-openjdk-amd64"
+
+  - label: "Publish artifacts"
+    command: "./gradlew :library:artifactoryPublish"
+    branches: "master"
     artifact_paths:
-      - "library/build/outputs/aar/library-release.aar"
-      - "library/build/outputs/aar/library-debug.aar"
+      - "library/build/outputs/aar/google-maps-clustering-release.aar"
+      - "library/build/outputs/aar/google-maps-clustering-debug.aar"

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,1 +1,1 @@
-majorVersion=1.0.1
+majorVersion=1.0.2


### PR DESCRIPTION
Changes:
+ Updated artifactory name to google-maps-clustering-release.aar and google-maps-clustering-debug.aar.
+ Only enable artifact publishing on master branch.